### PR TITLE
Feature: Add Two.Texture component implementation

### DIFF
--- a/lib/Texture.tsx
+++ b/lib/Texture.tsx
@@ -1,4 +1,4 @@
-import React, { useImperativeHandle, useEffect, useRef } from 'react';
+import React, { useImperativeHandle, useEffect, useRef, useCallback } from 'react';
 import Two from 'two.js';
 import { useTwo } from './Context';
 
@@ -23,19 +23,12 @@ export const Texture = React.forwardRef<Instance | null, ComponentProps>(
 
     const ref = useRef<Instance | null>(null);
 
-    if (!ref.current && two) {
+    if (!ref.current && two && source) {
       ref.current = new Two.Texture(source);
     }
 
-    useEffect(() => {
-      if (ref.current && source) {
-        ref.current.src = source;
-      }
-    }, [source]);
 
-    useEffect(update, [props]);
-
-    function update() {
+    const update = useCallback(() => {
       if (ref.current) {
         const texture = ref.current;
         for (const key in props) {
@@ -45,9 +38,11 @@ export const Texture = React.forwardRef<Instance | null, ComponentProps>(
           }
         }
       }
-    }
+    }, [props]);
 
-    useImperativeHandle(forwardedRef, () => ref.current!);
+    useEffect(update, [update]);
+
+    useImperativeHandle(forwardedRef, () => ref.current, []);
 
     return null; // No visual representation
   }

--- a/lib/Texture.tsx
+++ b/lib/Texture.tsx
@@ -1,0 +1,54 @@
+import React, { useImperativeHandle, useEffect, useRef } from 'react';
+import Two from 'two.js';
+import { useTwo } from './Context';
+
+import type { Texture as Instance } from 'two.js/src/effects/texture';
+import { ElementProps } from './Properties';
+
+type TextureProps = ElementProps | 'src' | 'offset' | 'repeat' | 'scale';
+
+type ComponentProps = React.PropsWithChildren<
+  {
+    [K in TextureProps]?: Instance[K];
+  } & {
+    source?: string | HTMLImageElement | HTMLCanvasElement | HTMLVideoElement;
+  }
+>;
+
+export type RefTexture = Instance;
+
+export const Texture = React.forwardRef<Instance | null, ComponentProps>(
+  ({ source, ...props }, forwardedRef) => {
+    const { two } = useTwo();
+
+    const ref = useRef<Instance | null>(null);
+
+    if (!ref.current && two) {
+      ref.current = new Two.Texture(source);
+    }
+
+    useEffect(() => {
+      if (ref.current && source) {
+        ref.current.src = source;
+      }
+    }, [source]);
+
+    useEffect(update, [props]);
+
+    function update() {
+      if (ref.current) {
+        const texture = ref.current;
+        for (const key in props) {
+          if (key in texture) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (texture as any)[key] = (props as any)[key];
+          }
+        }
+      }
+    }
+
+    useImperativeHandle(forwardedRef, () => ref.current!);
+
+    return null; // No visual representation
+  }
+);

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -20,3 +20,6 @@ export { Star, type RefStar } from './Star';
 // Gradient exports
 export { LinearGradient, type RefLinearGradient } from './LinearGradient';
 export { RadialGradient, type RefRadialGradient } from './RadialGradient';
+
+// Texture exports
+export { Texture, type RefTexture } from './Texture';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,8 @@ import {
   RefLinearGradient,
   RadialGradient,
   RefRadialGradient,
+  Texture,
+  RefTexture,
   Text,
 } from '../lib/main';
 import { useRef, useState } from 'react';
@@ -60,6 +62,9 @@ function Scene() {
   const [radialGradient, setRadialGradient] = useState<
     string | RefRadialGradient
   >('#F7DC6F');
+  
+  // Texture ref
+  const [texture, setTexture] = useState<string | RefTexture>('#E8E8E8');
 
   useFrame((elapsed) => {
     // Animate all the components
@@ -310,9 +315,20 @@ function Scene() {
         />
       </Group>
 
-      {/* <Group x={cellWidth * 1.5} y={cellHeight * 3.5}>
-        <Text value="Demo" fill="#E67E22" size={18} baseline="middle" />
-      </Group> */}
+      {/* Texture Example */}
+      <Group x={cellWidth * 3.5} y={cellHeight * 3.5}>
+        <Texture
+          ref={(ref) => ref && setTexture(ref)}
+          source="https://placehold.co/60x60/9B59B6/FFFFFF?text=TEX"
+        />
+        <Rectangle
+          width={60}
+          height={40}
+          fill={texture}
+          stroke="#333"
+          linewidth={2}
+        />
+      </Group>
     </Group>
   );
 }


### PR DESCRIPTION
- Implement Texture component in /lib/Texture.tsx following RadialGradient pattern
- Include Two.Texture.Properties and constructor arguments as props
- Export component in /lib/main.ts
- Add texture example usage in /src/App.tsx with textured Rectangle
- Support source prop for image/canvas/video elements
- Include proper TypeScript types and useEffect for property updates

Resolves #1