### PR TITLE
Improve Two.js resize handling in Provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.3",
         "@vitest/ui": "^3.2.4",
+        "baseline-browser-mapping": "^2.9.14",
         "clsx": "^2.1.1",
         "eslint": "^9.13.0",
         "eslint-plugin-react-hooks": "^5.0.0",
@@ -3371,9 +3372,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.10",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.10.tgz",
-      "integrity": "sha512-uLfgBi+7IBNay8ECBO2mVMGZAc1VgZWEChxm4lv+TobGdG82LnXMjuNGo/BSSZZL4UmkWhxEHP2f5ziLNwGWMA==",
+      "version": "2.9.14",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.14.tgz",
+      "integrity": "sha512-B0xUquLkiGLgHhpPBqvl7GWegWBUNuujQ6kXd/r1U38ElPT6Ok8KZ8e+FpUGEc2ZoRQUzq/aUnaKFc/svWUGSg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.3",
     "@vitest/ui": "^3.2.4",
+    "baseline-browser-mapping": "^2.9.14",
     "clsx": "^2.1.1",
     "eslint": "^9.13.0",
     "eslint-plugin-react-hooks": "^5.0.0",


### PR DESCRIPTION
Refactored the Provider component to better handle Two.js instance resizing, distinguishing between fitted and non-fitted modes. Also updated baseline-browser-mapping to version 2.9.14 in dependencies.

Addresses:

- https://github.com/jonobr1/react-two.js/issues/23